### PR TITLE
Aws aumentou o número de conexões com o Fargate para 100

### DIFF
--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -254,7 +254,7 @@ class Create extends React.Component {
                                     type="number"
                                     name="taskCount"
                                     id="taskCount"
-                                    max={50}
+                                    max={100}
                                     min={1}
                                     step={1}
                                     required
@@ -262,7 +262,7 @@ class Create extends React.Component {
                                 />
                                 <FormText color="muted">
                                     Number of docker containers that will be launched in the Fargate cluster to run the
-                                    test scenario, max value 50.
+                                    test scenario, max value 100.
                                 </FormText>
                             </FormGroup>
 


### PR DESCRIPTION
Alteração no frontend da aplicação que limita em 50 conexão com o Fargate. A Aws aumentou esse valor, recentemente, para 100.

Changing frontend to accept 100 conections with Fargate. AWS changed this recently.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
