### PR TITLE
Changing max file size to 100 MB

### DIFF
--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -22,7 +22,7 @@ import * as shortid from 'shortid';
 import 'brace/theme/github';
 
 // Upload file size limit
-const FILE_SIZE_LIMIT = 5 * 1024 * 1024;
+const FILE_SIZE_LIMIT = 100 * 1024 * 1024;
 
 // Allowed file extentions
 const FILE_EXTENSIONS = ['jmx'];


### PR DESCRIPTION
Currently this is preventing us from uploading some of our larger jmx files that have been bundled with vast quantities of test run data.

Issue #23 - 5 MB file limit seems arbitrary and small

Just bumping max file size UI limit to 100 MB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.