### PR TITLE
Added support to the Docker image pipleine to use explicit Docker Hub credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To make changes to the solution, download or clone this repo, update the source 
 ### Prerequisites:
 * [AWS Command Line Interface](https://aws.amazon.com/cli/)
 * Node.js 12.x or later
+* Optionally, a Docker Hub account (to alleviate [anonymous access rate limiting](https://www.docker.com/increase-rate-limits))
 
 ### 1. Clone the Distributed Load Testing on AWS solution repository
 Clone the ```distributed-load-testing-on-aws``` GitHub repositroy, then make the desired code changes.
@@ -97,6 +98,20 @@ aws s3 cp ./global-s3-assets/ s3://$DIST_OUTPUT_BUCKET-$REGION/$SOLUTION_NAME/$V
 
 ### 7. Launch the CloudFormation template.
 * Get the link of the `distributed-load-testing-on-aws.template` uploaded to your Amazon S3 bucket.
+* _Optionally, the Docker image pipeline can use your own Docker Hub account, instead of authenticating anonymously._
+	1. _Create a temporary `dockerhub_creds.json` file containing your Docker Hub credentials:_
+		```
+		{
+			"username": "your_dockerhub_username",
+			"password": "your_dockerhub_access_token"
+		}
+		```
+	2. _Create an AWS Secrets Manager secret containing these credentials:_
+		```bash
+		aws secretsmanager create-secret --name dockerhub --description "for $SOLUTION_NAME $VERSION" --secret-string file://dockerhub_creds.json
+        rm dockerhub_creds.json
+		```
+	3. _Make note of the secret ARN returned in the previous step, and provide it when asked during launch of the CloudFormation stack below._
 * Deploy the Distributed Load Testing on AWS solution to your account by launching a new AWS CloudFormation stack using the link of the `distributed-load-testing-on-aws.template`.
 
 ***

--- a/deployment/distributed-load-testing-on-aws.yaml
+++ b/deployment/distributed-load-testing-on-aws.yaml
@@ -19,6 +19,13 @@ Parameters:
     AllowedPattern: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
     ConstraintDescription: "Admin email must be a valid email address"
 
+  SecretsManagerDockerHubCredsArn:
+    Type: String
+    Default: ''
+    Description: ARN of an AWS Secrets Manager secret containing your Docker Hub username and password (or access token) to alleviate Docker Hub anonymous access rate limiting
+    AllowedPattern: "^$|^arn:aws:secretsmanager:.*$"
+    ConstraintDescription: "must be a valid AWS Secrets Manager secret ARN or left blank"
+
   VpcCidrBlock:
     Type: String
     Default: 192.168.0.0/16
@@ -68,6 +75,10 @@ Metadata:
           - SubnetACidrBlock
           - SubnetBCidrBlock
           - EgressCidr
+      - Label:
+          default: "(Optional) Docker Hub Account"
+        Parameters:
+          - SecretsManagerDockerHubCredsArn
     ParameterLabels:
       AdminName:
         default: "Console Administrator Name"
@@ -81,6 +92,8 @@ Metadata:
         default: "AWS Fargate Subnet B CIDR Block"
       EgressCidr:
         default: "AWS Fargate SecurityGroup CIDR Block"
+      SecretsManagerDockerHubCredsArn:
+        default: "AWS Secrets Manager secret for Docker Hub credentials"
 
 Mappings:
   SourceCode:
@@ -94,6 +107,7 @@ Mappings:
 
 Conditions:
   Metrics: !Equals [ !FindInMap [AnonymousData, SendAnonymousData, Data], "Yes" ]
+  UseDockerHubCreds: !Not [ !Equals [ !Ref SecretsManagerDockerHubCredsArn, '' ] ]
 
 Resources:
 
@@ -412,6 +426,14 @@ Resources:
                 Resource:
                     - !Sub ${ContainerBucket.Arn}
                     - !Sub ${ContainerBucket.Arn}/*
+              - !If
+                  - UseDockerHubCreds
+                  - Effect: Allow
+                    Action:
+                      - secretsmanager:GetSecretValue
+                    Resource:
+                      - !Ref SecretsManagerDockerHubCredsArn
+                  - !Ref "AWS::NoValue"
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -843,6 +865,18 @@ Resources:
             Value: !Sub ${EcrRepository}
           - Name: REPOSITORY_URI
             Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrRepository}
+          - !If
+            - UseDockerHubCreds
+            - Name: DOCKERHUB_USERNAME
+              Type: SECRETS_MANAGER
+              Value: !Sub '${SecretsManagerDockerHubCredsArn}:username'
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseDockerHubCreds
+            - Name: DOCKERHUB_PASSWORD
+              Type: SECRETS_MANAGER
+              Value: !Sub '${SecretsManagerDockerHubCredsArn}:password'
+            - !Ref "AWS::NoValue"
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub |
@@ -850,16 +884,17 @@ Resources:
           phases:
               pre_build:
                 commands:
-                  - aws --version
-                  - echo $REPOSITORY
-                  - echo $REPOSITORY_URI
-                  - aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin $REPOSITORY_URI
+                  - "[ -z $DOCKERHUB_USERNAME ] || docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD"
               build:
                 commands:
                   - docker build -t $REPOSITORY:latest .
                   - docker tag $REPOSITORY:latest $REPOSITORY_URI:latest
               post_build:
                 commands:
+                  - aws --version
+                  - echo $REPOSITORY
+                  - echo $REPOSITORY_URI
+                  - aws ecr get-login-password --region ${AWS::Region} | docker login --username AWS --password-stdin $REPOSITORY_URI
                   - docker push $REPOSITORY_URI:latest
       Tags:
         - Key: SolutionId


### PR DESCRIPTION
**Issue:**

Docker rate limiting #31

**Description of changes:**

As per [changes](https://www.docker.com/increase-rate-limits) made last year (November 20, 2020) by Docker Hub:

> Anonymous and Free Docker Hub users are limited to 100 and 200 container image pull requests per six hours.

This resulted in the Docker image pipeline component intermittently failing for some as described in issue #31.

To work around this issue, I've updated the CloudFormation template parameters, conditions, CodeBuild environment,  buildspec, and role configurations to optionally utilize custom Docker Hub credentials if desired.  These credentials are retrieved from AWS Secrets Manager following the pattern laid out here: https://aws.amazon.com/blogs/devops/how-to-use-docker-images-from-a-private-registry-in-aws-codebuild-for-your-build-environment/

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
