### PR TITLE
Type feature: increase task limit to 500.

### DIFF
--- a/deployment/distributed-load-testing-on-aws.yaml
+++ b/deployment/distributed-load-testing-on-aws.yaml
@@ -1002,7 +1002,7 @@ Resources:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "task-runner.zip"]]
       Runtime: nodejs12.x
-      Timeout: 180
+      Timeout: 900
       Environment:
         Variables:
           SCENARIOS_BUCKET: !Ref ScenariosBucket

--- a/source/api-services/lib/scenarios/index.js
+++ b/source/api-services/lib/scenarios/index.js
@@ -132,9 +132,9 @@ const createTest = async (config) => {
         }
         if (!numRegex.test(taskCount)
             || parseInt(taskCount) < 1
-            || parseInt(taskCount) > 100) {
+            || parseInt(taskCount) > 500) {
             throw {
-                message: 'Task count should be positive number between 1 to 100.',
+                message: 'Task count should be positive number between 1 to 500.',
                 code: 'InvalidParameter',
                 status: 400
              };

--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -349,7 +349,7 @@ class Create extends React.Component {
                                     type="number"
                                     name="taskCount"
                                     id="taskCount"
-                                    max={100}
+                                    max={500}
                                     min={1}
                                     step={1}
                                     required
@@ -357,7 +357,7 @@ class Create extends React.Component {
                                 />
                                 <FormText color="muted">
                                     Number of docker containers that will be launched in the Fargate cluster to run the
-                                    test scenario, max value 100.
+                                    test scenario, max value 500.
                                 </FormText>
                             </FormGroup>
 


### PR DESCRIPTION
**Issue #, if available:**
As title.

**Description of changes:**
Although the Fargete Task limit has been increased from 100 to 1000, task_runner can only run 10 tasks in a loop, so each loop needs to wait for 10 seconds in order to avoid throttle. Therefore, we also need to increase the execution time of task-runner to the maximum limit of 900 seconds. In order to avoid Lambda execution timeout, I suggest raising the upper limit to 500 Tasks is a safe value.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

I have test this code in my end, I can execute complete test with 500 tasks and 200 concurrent. 
