### PR TITLE
Make the subnet B to use different AZ than subnet A

### DIFF
--- a/deployment/distributed-load-testing-on-aws.yaml
+++ b/deployment/distributed-load-testing-on-aws.yaml
@@ -492,7 +492,7 @@ Resources:
       CidrBlock: !Ref SubnetBCidrBlock
       AvailabilityZone:
         !Select
-          - 0
+          - 1
           - !GetAZs
       VpcId: !Ref Vpc
 


### PR DESCRIPTION
There is no reason to use same AZ in two subnet.
To follow best practice, changed the AZ of subnet B.

**Issue #, if available:**
#43 



**Description of changes:**
Changed the AZ of subnet B to different one than subnet A


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
