### PR TITLE
Fix #49 large zip scenario file upload failure

### DIFF
--- a/deployment/distributed-load-testing-on-aws.yaml
+++ b/deployment/distributed-load-testing-on-aws.yaml
@@ -633,6 +633,8 @@ Resources:
               - !Sub https://${ConsoleCloudFront.DomainName}
             AllowedHeaders:
               - '*'
+            ExposedHeaders:
+              - 'ETag'
       Tags:
         - Key: SolutionId
           Value: SO0062


### PR DESCRIPTION
When user uploads a large zip file for scenario file, the console generates an error message.

"Error ETagMissing: No access to ETag property on response. Check CORS configuration to expose ETag header."

Adding "ETag" header to ExposeHeaders will fix the error.
I references https://docs.amplify.aws/lib/storage/getting-started/q/platform/js#amazon-s3-bucket-cors-policy-setup and https://github.com/aws-amplify/amplify-cli/issues/297 for solutions.

**Issue #, if available:**
#49 



**Description of changes:**
Adding "ETag" header to ExposeHeaders of CORS Configuration of the scenario bucket.


**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
