### PR TITLE
Added WebACL and IPSet (for whitelisting) to restrict connectivity to the solution.

### DIFF
--- a/deployment/distributed-load-testing-on-aws.yaml
+++ b/deployment/distributed-load-testing-on-aws.yaml
@@ -56,6 +56,10 @@ Parameters:
   DockerHubSecret:
     Type: String
     Description: Name of Secrets Manager Secret containing Docker Hub credentials
+
+  WhiteListIPs:
+    Type: CommaDelimitedList
+    Description: (Optional) List of IP ranges allowed to access the solution. 
   
 Metadata:
   AWS::CloudFormation::Interface:
@@ -75,7 +79,11 @@ Metadata:
       - Label: 
           default: "Secrets Manager Secret"
         Parameters:
-          - DockerHubSecret
+          - DockerHubSecret 
+      - Label: 
+          default: "Web ACL settings"
+        Parameters:
+          - WhiteListIPs 
     ParameterLabels:
       AdminName:
         default: "Console Administrator Name"
@@ -91,6 +99,9 @@ Metadata:
         default: "AWS Fargate SecurityGroup CIDR Block"
       DockerHubSecret:
         default: "Docker Hub credentials Secret"
+      WhiteListIPs:
+        default: "If not set, the solution will be reachable by the public (e.g. 54.1.1.1/32, 3.2.2.2/32, 64.3.3.3/32)" 
+         
 Mappings:
   Solution:
     Config:
@@ -106,7 +117,7 @@ Mappings:
 Conditions:
   Metrics: !Equals [ !FindInMap [Solution, Config, SendAnonymousData], "Yes" ]
   SecretProvided: !Not [!Equals [!Ref DockerHubSecret, ""]]
-
+  WhiteListIPProvided: !Not [ !Equals [!Select [ "0", !Ref WhiteListIPs ], ""]]
 
 Resources:
 
@@ -1977,6 +1988,54 @@ Resources:
       SolutionId: !FindInMap [Solution, Config, SolutionId]
       UUID: !GetAtt Uuid.UUID
       Version: !FindInMap [Solution, Config, CodeVersion]
+
+# WebACL resources
+  WebACL:
+    Condition: WhiteListIPProvided
+    Type: 'AWS::WAFv2::WebACL'
+    Properties: 
+      Name: webacl
+      Description: Web access control list for DLTA       
+      Scope: CLOUDFRONT      
+      DefaultAction:       # By default all access is blocked
+        Block:
+          CustomResponse:
+            ResponseCode: 503
+      Rules: 
+        - Name: WhiteListRule
+          Priority: 0        
+          Action: 
+            Allow:
+              CustomRequestHandling:
+                InsertHeaders:
+                  - Name: AllowActionHeader1Name
+                    Value: AllowActionHeader1Value
+                  - Name: AllowActionHeader2Name
+                    Value: AllowActionHeader2Value
+          Statement:
+            IPSetReferenceStatement: 
+              Arn: !GetAtt WhiteListIPSet.Arn
+          VisibilityConfig: 
+            CloudWatchMetricsEnabled: true
+            MetricName: dlta-webacl-rule-0
+            SampledRequestsEnabled: true              
+      Tags:
+        - Key: SolutionId
+          Value: !FindInMap [Solution, Config, SolutionId]
+      VisibilityConfig: 
+        CloudWatchMetricsEnabled: true
+        MetricName: dlta-webacl
+        SampledRequestsEnabled: true
+
+  WhiteListIPSet:
+    Condition: WhiteListIPProvided
+    Type: 'AWS::WAFv2::IPSet'
+    Properties:
+      Description: Web ACL White List IP Set
+      Name: whitelistipset
+      Scope: CLOUDFRONT
+      IPAddressVersion: IPV4
+      Addresses: !Ref WhiteListIPs   
 
 Outputs:
   Console:


### PR DESCRIPTION
… useful when the solution should only be accessible behind VPN

**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

**Description of changes:**
<!-- Please describe the changes you made -->
The solution has a risk of external attacks due to public accessibility. This change will restrict the connectivity to certain IP addresses:
Added the following resources:
- WebACL (AWS::WAFv2::WebACL)
- WhiteListIPSet(AWS::WAFv2::IPSet)
The above resources are created when the value of parameter WhiteListIPs (CommaDelimitedList) is not empty

**Checklist**
- [x ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
